### PR TITLE
SD-33: Make sign modal dismissable

### DIFF
--- a/src/domains/misc/components/Modal/LazyLoadedModal.tsx
+++ b/src/domains/misc/components/Modal/LazyLoadedModal.tsx
@@ -156,7 +156,7 @@ const LazyLoadedModal = forwardRef<ModalRef, Props>(({
               setIsVisible(true);
               setIsOpen(true);
             } else {
-              void initiateClosing();
+              void initiateClosing(!nonDismissable);
             }
           }}
         >

--- a/src/domains/shielder/components/SignatureModal.tsx
+++ b/src/domains/shielder/components/SignatureModal.tsx
@@ -74,7 +74,7 @@ const SignatureModal = () => {
   const isError = isTryingAgain || isSigningError || !isConnected;
 
   return (
-    <StyledModal isModalOpen={isConnected && !shielderPrivateKey && isNetworkSupported } nonDismissable>
+    <StyledModal isModalOpen={isConnected && !shielderPrivateKey && isNetworkSupported }>
       <Content>
         <CheckedContainer>
           <SignatureIcon size={60} icon="Signature" color={isError ? vars('--color-status-danger-foreground-1-rest') : undefined} />


### PR DESCRIPTION
We need this in case of problem with signature on the wallet side, so that user can dismiss the modal and disconnect.