### PR TITLE
SD-51: Fix waiting for tx receipt

### DIFF
--- a/src/domains/shielder/utils/useShielderClient.tsx
+++ b/src/domains/shielder/utils/useShielderClient.tsx
@@ -101,7 +101,7 @@ const useShielderClient = () => {
                 }
 
                 try {
-                  const receipt = await client.getTransactionReceipt({ hash: tx.txHash });
+                  const receipt = await client.waitForTransactionReceipt({ hash: tx.txHash });
                   const block = await client.getBlock({ blockHash: receipt.blockHash });
                   return Number(block.timestamp) * 1000;
                 } catch (error) {


### PR DESCRIPTION
With the previous method I sometimes got "missing receipt" error. While the difference between these 2 methods is not fully clear, some clues indicate that the new one waits for the transaction to be available instead of just checking once, like the old one, which should solve the problem.