### PR TITLE
SD-78: Fix modal displayed on disconnect click

### DIFF
--- a/src/domains/misc/utils/getQueryKey.ts
+++ b/src/domains/misc/utils/getQueryKey.ts
@@ -1,36 +1,91 @@
+export const QUERY_KEYS = {
+  shielderFees: 'shielderFees',
+  shielderClient: 'shielder-client',
+  shielderTransactions: 'shielder-transactions',
+  tokenDecimals: 'token-decimals',
+  tokenName: 'token-name',
+  tokenSymbol: 'token-symbol',
+  tokenPublicBalance: 'token-public-balance',
+  tokenShieldedBalance: 'token-shielded-balance',
+  shielderPrivateKey: 'shielderPrivateKey',
+  wasmCryptoClient: 'wasm-crypto-client',
+} as const;
+
 import type { Address } from 'viem';
 
 import { NetworkEnvironment } from 'src/domains/chains/types/misc';
 
 const getQueryKey = {
-  shielderFees: (walletAddress: Address, chainId: string) => ['shielderFees', walletAddress, chainId] ,
+  shielderFees: (walletAddress: Address, chainId: string) => [
+    QUERY_KEYS.shielderFees,
+    walletAddress,
+    chainId,
+  ],
   shielderClient: (chainId: number, shielderPrivateKey: Address) => [
-    'shielder-client',
+    QUERY_KEYS.shielderClient,
     chainId,
     shielderPrivateKey,
-  ] ,
+  ],
   shielderTransactions: (accountAddress: Address, chainId: number) => [
-    'shielder-transactions',
+    QUERY_KEYS.shielderTransactions,
     accountAddress,
     chainId,
-  ] ,
-  tokenDecimals: (tokenAddress: Address | 'native', chainId: string) => ['token-decimals', chainId, tokenAddress],
-  tokenName: (tokenAddress: Address | 'native', chainId: string) => ['token-name', chainId, tokenAddress] ,
-  tokenSymbol: (tokenAddress: Address | 'native', chainId: string) => ['token-symbol', chainId, tokenAddress] ,
-  tokenPublicBalance: (tokenAddress: Address | 'native', chainId: string, walletAddress: Address) => [
-    'token-public-balance',
+  ],
+  tokenDecimals: (
+    tokenAddress: Address | 'native',
+    chainId: string
+  ) => [
+    QUERY_KEYS.tokenDecimals,
+    chainId,
+    tokenAddress,
+  ],
+  tokenName: (
+    tokenAddress: Address | 'native',
+    chainId: string
+  ) => [
+    QUERY_KEYS.tokenName,
+    chainId,
+    tokenAddress,
+  ],
+  tokenSymbol: (
+    tokenAddress: Address | 'native',
+    chainId: string
+  ) => [
+    QUERY_KEYS.tokenSymbol,
+    chainId,
+    tokenAddress,
+  ],
+  tokenPublicBalance: (
+    tokenAddress: Address | 'native',
+    chainId: string,
+    walletAddress: Address
+  ) => [
+    QUERY_KEYS.tokenPublicBalance,
     tokenAddress,
     chainId,
     walletAddress,
-  ] ,
-  tokenShieldedBalance: (tokenAddress: Address | 'native', chainId: string, walletAddress: Address) => [
-    'token-shielded-balance',
+  ],
+  tokenShieldedBalance: (
+    tokenAddress: Address | 'native',
+    chainId: string,
+    walletAddress: Address
+  ) => [
+    QUERY_KEYS.tokenShieldedBalance,
     tokenAddress,
     chainId,
     walletAddress,
-  ] ,
-  shielderPrivateKey: (walletAddress: Address, networkEnvironment: NetworkEnvironment) => ['shielderPrivateKey', networkEnvironment, walletAddress] ,
-  wasmCryptoClient: () => ['wasm-crypto-client'] ,
+  ],
+  shielderPrivateKey: (
+    walletAddress: Address,
+    networkEnvironment: NetworkEnvironment
+  ) => [
+    QUERY_KEYS.shielderPrivateKey,
+    networkEnvironment,
+    walletAddress,
+  ],
+  wasmCryptoClient: () => [
+    QUERY_KEYS.wasmCryptoClient,
+  ],
 };
 
 export default getQueryKey;


### PR DESCRIPTION
This PR solves few issues:

[SD-78](https://cardinal-cryptography.atlassian.net/jira/software/projects/SD/boards/120?selectedIssue=SD-78) 

- We were clearing storage/cache before disconnecting user, so for some short time user was still connected but had no privateKey saved.

[SD-86](https://cardinal-cryptography.atlassian.net/jira/software/projects/SD/boards/120?selectedIssue=SD-86)

Also previously we were clearing cache/storage when user manually clicked disconnect, but apparently user can get disconnected automatically/manually by wallet (e.g. after its locked). So in this implementation I do cleaning after its detected that user is disconnected.

[SD-78]: https://cardinal-cryptography.atlassian.net/browse/SD-78?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SD-86]: https://cardinal-cryptography.atlassian.net/browse/SD-86?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ