### PR TITLE
SD-101: Fix newAccountERC20 arithmetic underflow error

### DIFF
--- a/src/domains/shielder/utils/useShield.tsx
+++ b/src/domains/shielder/utils/useShield.tsx
@@ -120,12 +120,14 @@ const useShield = () => {
         });
 
         if (allowance < amount) {
-          await walletClient.writeContract({
+          const approveTxHash = await walletClient.writeContract({
             address: token.address,
             abi: erc20Abi,
             functionName: 'approve',
             args: [chainConfig.shielderConfig.shielderContractAddress, amount],
           });
+
+          await publicClient.waitForTransactionReceipt({ hash: approveTxHash });
         }
       }
 


### PR DESCRIPTION
We were sending the shielding transaction before waiting for the approval transaction to be confirmed, which caused the contract to execute newAccountERC20 with unapproved tokens. This led to an arithmetic underflow error because the contract couldn't properly access the tokens. The fix adds a wait for the approval transaction receipt before proceeding with the shielding operation, ensuring the tokens are properly approved before the contract attempts to use them.