### PR TITLE
SD-106: Remove NPM_TOKEN

### DIFF
--- a/.github/actions/build-and-push/action.yml
+++ b/.github/actions/build-and-push/action.yml
@@ -64,12 +64,6 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
 
-    - name: Set NPM_TOKEN
-      env:
-        NPM_TOKEN: ${{ inputs.npm-token }}
-      shell: bash
-      run: npm config set '//registry.npmjs.org/:_authToken' "${{ env.NPM_TOKEN }}"
-
     - name: Clean install
       shell: bash
       run: npm ci

--- a/.github/actions/setup-project/action.yml
+++ b/.github/actions/setup-project/action.yml
@@ -1,11 +1,6 @@
 name: Setup project
 description: Setup npm project in Node.js
 
-inputs:
-  NPM_TOKEN:
-    required: true
-    description: NPM_TOKEN
-
 outputs:
   node-version:
     description: The resolved and installed Node.js version.
@@ -32,12 +27,8 @@ runs:
         key: os-${{ runner.os }}/node-${{ steps.node.outputs.version }}/node_modules-${{ hashFiles('package-lock.json') }}
     - name: Install dependencies
       if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
-      run: |
-        echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
-        npm ci
+      run: npm ci
       shell: bash
-      env:
-        NPM_TOKEN: ${{ inputs.NPM_TOKEN }}
     - name: Cache node_modules
       if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
       uses: actions/cache@v4

--- a/.github/workflows/build-and-push-prod.yml
+++ b/.github/workflows/build-and-push-prod.yml
@@ -30,4 +30,3 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_S3_PROD_SECRET_ACCESS_KEY }}
           s3-bucket-name: ${{ secrets.AWS_S3_PROD_BUCKET_NAME }}
           amplify-app-id: ${{ secrets.AWS_AMPLIFY_PROD_APP_ID }}
-          npm-token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/build-and-push-stage.yml
+++ b/.github/workflows/build-and-push-stage.yml
@@ -30,4 +30,3 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_S3_STAGE_SECRET_ACCESS_KEY }}
           s3-bucket-name: ${{ secrets.AWS_S3_STAGE_BUCKET_NAME }}
           amplify-app-id: ${{ secrets.AWS_AMPLIFY_STAGE_APP_ID }}
-          npm-token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-project
-        with:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   storybook:
     name: Chromatic toolset initialization

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-project
-        with:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   lint-commits:
     name: Lint commits
@@ -23,8 +21,6 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-project
-        with:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: npx commitlint --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} --to ${{ github.event.pull_request.head.sha }} --verbose
 
   type-check:
@@ -34,8 +30,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-project
-        with:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: npm run type-check
 
   lint:
@@ -45,8 +39,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-project
-        with:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: npm run lint
 
   test:
@@ -57,8 +49,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-project
-        with:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Export variables
         shell: bash
         env:


### PR DESCRIPTION
It used to be necessary for the shielder sdk private packages, but they're all public already. Managing the token was problematic too.